### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: BuildTest
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore crn.2010.sln
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=Release_DLL /p:Platform=x64 crn.2010.sln
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: crunch-windows-x64
+        path: ${{ github.workspace }}\lib\VC9\Release_DLL\x64
+
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config Release
+
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: crunch-linux-x64
+        path: ${{ github.workspace }}/build


### PR DESCRIPTION
This is probably pretty messy, but I've tested the built binary with the Unity clients, without incident, both loading and importing images. I have no idea how to trigger an image to compress on the headless, as the import command doesn't work.