### PR TITLE
CI/CD for Windows, Linux (and Linux ARM)

### DIFF
--- a/.github/workflows/ydms-build.yaml
+++ b/.github/workflows/ydms-build.yaml
@@ -38,3 +38,21 @@ jobs:
         with:
           name: ${{ env.distname }}
           path: ${{ env.builddir }}/**/*.so
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup msbuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build solution
+        run: |
+          msbuild -target:build -property:Configuration=Release_DLL -property:Platform=x64 -m crn.2010.sln
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: crunch-windows
+          path: lib/**/*.dll

--- a/.github/workflows/ydms-build.yaml
+++ b/.github/workflows/ydms-build.yaml
@@ -1,0 +1,40 @@
+name: "YDMS Build"
+
+on: [push]
+
+jobs:
+  build-linux:
+    strategy:
+      matrix:
+        osver: [ubuntu-latest, ubuntu-24.04-arm]
+
+    runs-on: ${{ matrix.osver }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set dist name
+        run: |
+          if ${{ matrix.osver == 'ubuntu-24.04-arm' }}; then
+            echo "distname=crunch-linux-arm" >> "$GITHUB_ENV"
+          else
+            echo "distname=crunch-linux" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create build dirs
+        run: |
+          mkdir build
+          cd build
+          echo "builddir=$(pwd)" >> "$GITHUB_ENV"
+
+      - name: Build crunch Linux
+        working-directory: ${{ env.builddir }}
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          make -j4
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.distname }}
+          path: ${{ env.builddir }}/**/*.so

--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -21,6 +21,7 @@
 #include <memory.h>
 #else
 #include <malloc.h>
+#include <cstdint>
 #endif
 #include <stdarg.h>
 #include <new>  // needed for placement new, _msize, _expand


### PR DESCRIPTION
This PR adds Linux and Windows CI/CD builds.

Adds:
- Windows builds
  - Builds the x64 Release_DLL version
  - Uploads an artifact `crunch-windows`
- Linux builds
  - Uploads an artifact `crunch-linux` for the x64 version
  - Uploads an artifact `crunch-linux-arm` for the ARM version

Changes:
- Import `cstdint` in `inc/crn_decomp.h` to make Linux build correctly

---

Proofs:
- Windows build: https://github.com/jae1911/crunch-ydms/actions/runs/13094910694/job/36536030787
- Linux x64 build: https://github.com/jae1911/crunch-ydms/actions/runs/13094910694/job/36536030843
- Linux ARM build: https://github.com/jae1911/crunch-ydms/actions/runs/13094910694/job/36536030893